### PR TITLE
Write headers immediately

### DIFF
--- a/sse.go
+++ b/sse.go
@@ -77,6 +77,7 @@ func (s *Server) ServeHTTP(response http.ResponseWriter, request *http.Request) 
         }()
         
         response.WriteHeader(http.StatusOK)
+        flusher.Flush()
 
         for msg := range c.send {
             msg.retry = s.options.RetryInterval


### PR DESCRIPTION
Flush all headers. This can help inform any reverse proxies of relevant headers and prevent them from dropping connections due to inactivity. 