### PR TITLE
Multiline messages support

### DIFF
--- a/message.go
+++ b/message.go
@@ -3,6 +3,7 @@ package sse
 import (
 	"bytes"
 	"fmt"
+	"strings"
 )
 
 // Message represents a event source message.
@@ -42,7 +43,7 @@ func (m *Message) String() string {
 	}
 
 	if len(m.data) > 0 {
-		buffer.WriteString(fmt.Sprintf("data: %s\n", m.data))
+		buffer.WriteString(fmt.Sprintf("data: %s\n", strings.Replace(m.data, "\n", "\ndata: ", -1)))
 	}
 
 	buffer.WriteString("\n")

--- a/message_test.go
+++ b/message_test.go
@@ -30,3 +30,11 @@ func TestMessage(t *testing.T) {
 		t.Fatal("Messagem not empty.")
 	}
 }
+
+func TestMultilineDataMessage(t *testing.T) {
+	msg := Message{data: "test\ntest"}
+
+	if msg.String() != "data: test\ndata: test\n\n" {
+		t.Fail()
+	}
+}


### PR DESCRIPTION
https://www.html5rocks.com/en/tutorials/eventsource/basics/#toc-multiline-data

> If your message is longer, you can break it up by using multiple "data:" lines. Two or more consecutive lines beginning with "data:" will be treated as a single piece of data, meaning only one message event will be fired. Each line should end in a single "\n" (except for the last, which should end with two)