### PR TITLE
add x-accel-buffering header and set to no

### DIFF
--- a/examples/complex.go
+++ b/examples/complex.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/alexandrevicenzi/go-sse"
+	"github.com/kabaluyot/go-sse"
 )
 
 func main() {

--- a/examples/simple.go
+++ b/examples/simple.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/alexandrevicenzi/go-sse"
+	"github.com/kabaluyot/go-sse"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,1 @@
-module github.com/kabaluyot/go-sse
+module github.com/alexandrevicenzi/go-sse

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,1 @@
-module github.com/alexandrevicenzi/go-sse
+module github.com/kabaluyot/go-sse

--- a/sse.go
+++ b/sse.go
@@ -67,6 +67,7 @@ func (s *Server) ServeHTTP(response http.ResponseWriter, request *http.Request) 
 		h.Set("Content-Type", "text/event-stream")
 		h.Set("Cache-Control", "no-cache")
 		h.Set("Connection", "keep-alive")
+		h.Set("X-Accel-Buffering", "no")
 
 		var channelName string
 


### PR DESCRIPTION
As per discussion here, [https://serverfault.com/questions/801628/for-server-sent-events-sse-what-nginx-proxy-configuration-is-appropriate](url), the header above will solve the buffering issue that this package do when deployed in production with proxy servers (nginx, apache).