### PR TITLE
include accel buffering in response headers

### DIFF
--- a/sse.go
+++ b/sse.go
@@ -67,6 +67,7 @@ func (s *Server) ServeHTTP(response http.ResponseWriter, request *http.Request) 
 		h.Set("Content-Type", "text/event-stream")
 		h.Set("Cache-Control", "no-cache")
 		h.Set("Connection", "keep-alive")
+		h.Set("X-Accel-Buffering", "no")
 
 		var channelName string
 


### PR DESCRIPTION
To avoid buffering when using reverse proxy apps like nginx, apache, etc, please include this response header as discussed [here](https://serverfault.com/questions/801628/for-server-sent-events-sse-what-nginx-proxy-configuration-is-appropriate)