### PR TITLE
Fix use of fmt.Fprintf when writing messages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/alexandrevicenzi/go-sse
+module github.com/wdscxsj/go-sse
 
 go 1.11

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/wdscxsj/go-sse
+module github.com/alexandrevicenzi/go-sse
 
 go 1.11

--- a/message.go
+++ b/message.go
@@ -29,7 +29,7 @@ func NewMessage(id, data, event string) *Message {
 	}
 }
 
-func (m *Message) String() string {
+func (m *Message) Buffer() *bytes.Buffer {
 	var buffer bytes.Buffer
 
 	if len(m.id) > 0 {
@@ -50,5 +50,13 @@ func (m *Message) String() string {
 
 	buffer.WriteString("\n")
 
-	return buffer.String()
+	return &buffer
+}
+
+func (m *Message) String() string {
+	return m.Buffer().String()
+}
+
+func (m *Message) Bytes() []byte {
+	return m.Buffer().Bytes()
 }

--- a/message_test.go
+++ b/message_test.go
@@ -38,3 +38,11 @@ func TestMultilineDataMessage(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func TestSpecialCharacterMessage(t *testing.T) {
+	msg := Message{data: "%x%o"}
+
+	if msg.String() != "data: %x%o\n\n" {
+		t.Fatal("Message does not match.")
+	}
+}

--- a/sse.go
+++ b/sse.go
@@ -1,7 +1,6 @@
 package sse
 
 import (
-	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -92,7 +91,7 @@ func (s *Server) ServeHTTP(response http.ResponseWriter, request *http.Request) 
 
 		for msg := range c.send {
 			msg.retry = s.options.RetryInterval
-			fmt.Fprintf(response, msg.String())
+			response.Write(msg.Bytes())
 			flusher.Flush()
 		}
 	} else if request.Method != "OPTIONS" {


### PR DESCRIPTION
On line 95 of `sse.go`, `fmt.Fprintf` should be `fmt.Fprint` to properly handle messages containing `%` characters.

This PR also refactors the message serialization part to save a []byte/string conversion, with a test added.