### PR TITLE
Fix bench BenchmarkSendMessage

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -79,6 +79,8 @@ func BenchmarkSendMessage(b *testing.B) {
 			wgReg.Add(1)
 			wgCh.Add(1)
 
+			name := name
+			ch := ch
 			go func() {
 				c := newClient("", name)
 				ch.addClient(c)

--- a/message.go
+++ b/message.go
@@ -54,12 +54,12 @@ func (m *Message) Buffer() *bytes.Buffer {
 	return &buffer
 }
 
-// String returns the formated message as a string.
+// String returns the formatted message as a string.
 func (m *Message) String() string {
 	return m.Buffer().String()
 }
 
-// Bytes returns the formated message as a byte array.
+// Bytes returns the formatted message as a byte array.
 func (m *Message) Bytes() []byte {
 	return m.Buffer().Bytes()
 }


### PR DESCRIPTION
Hello,

Here is another minor fix.

* Loop variable captured in function literal
See https://golang.org/doc/faq#closures_and_goroutines

* Unrelated : fix typo in comments (in `message.go`)