### PR TITLE
Add Iris (go module) example

### DIFF
--- a/_examples/README.md
+++ b/_examples/README.md
@@ -8,5 +8,6 @@ Examples on how to use `go-sse` with multiple libraries and frameworks.
 | [echo](https://github.com/labstack/echo)        | ✔ | [echo.go](https://github.com/alexandrevicenzi/go-sse/blob/master/_examples/echo.go) |
 | [fasthttp](https://github.com/valyala/fasthttp) | ✘ | |
 | [gin](https://github.com/gin-gonic/gin)         | ✔ | [gin.go](https://github.com/alexandrevicenzi/go-sse/blob/master/_examples/gin.go) |
+| [iris](https://github.com/kataras/iris)         | ✔ | [iris/main.go](https://github.com/alexandrevicenzi/go-sse/blob/master/_examples/iris/main.go) |
 | [gorilla/mux](https://github.com/gorilla/mux)   | ✔ | [gorilla.go](https://github.com/alexandrevicenzi/go-sse/blob/master/_examples/gorilla.go) |
 | `net/http`                                      | ✔ | [net_http.go](https://github.com/alexandrevicenzi/go-sse/blob/master/_examples/net_http.go) or [net_http_options.go](https://github.com/alexandrevicenzi/go-sse/blob/master/_examples/net_http_options.go) |

--- a/_examples/iris/go.mod
+++ b/_examples/iris/go.mod
@@ -1,0 +1,8 @@
+module iris_example
+
+go 1.15
+
+require (
+	github.com/alexandrevicenzi/go-sse v1.6.0
+	github.com/kataras/iris/v12 v12.2.0-alpha2.0.20210127020946-ce25e698f8f8
+)

--- a/_examples/iris/main.go
+++ b/_examples/iris/main.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/alexandrevicenzi/go-sse"
+	"github.com/kataras/iris/v12"
+)
+
+func main() {
+	s := sse.NewServer(&sse.Options{
+		// Increase default retry interval to 10s.
+		RetryInterval: 10 * 1000,
+		// CORS headers
+		Headers: map[string]string{
+			"Access-Control-Allow-Origin":  "*",
+			"Access-Control-Allow-Methods": "GET, OPTIONS",
+			"Access-Control-Allow-Headers": "Keep-Alive,X-Requested-With,Cache-Control,Content-Type,Last-Event-ID",
+		},
+		// Custom channel name generator
+		ChannelNameFunc: func(request *http.Request) string {
+			return request.URL.Path
+		},
+		// Print debug info
+		Logger: log.New(os.Stdout, "go-sse: ", log.Ldate|log.Ltime|log.Lshortfile),
+	})
+
+	defer s.Shutdown()
+
+	app := iris.New()
+	app.Get("/", func(ctx iris.Context) {
+		ctx.ServeFile("../static/index.html")
+	})
+	app.Get("/events/{channel}", iris.FromStd(s))
+
+	go func() {
+		for {
+			s.SendMessage("/events/channel-1", sse.SimpleMessage(time.Now().Format("2006/02/01/ 15:04:05")))
+			time.Sleep(5 * time.Second)
+		}
+	}()
+
+	go func() {
+		i := 0
+		for {
+			i++
+			s.SendMessage("/events/channel-2", sse.SimpleMessage(strconv.Itoa(i)))
+			time.Sleep(5 * time.Second)
+		}
+	}()
+
+	app.Listen(":3000")
+}


### PR DESCRIPTION
Hello @alexandrevicenzi,

This PR contains a simple example for the [Iris](https://github.com/kataras/iris) web framework. The [organisation](https://github.com/responsibility-act) is also responsible for its maintainability so you don't have to worry about in the future.