### PR TITLE
Fix datarace while update a channel.lastEventID

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -23,7 +23,9 @@ func newChannel(name string) *Channel {
 
 // SendMessage broadcast a message to all clients in a channel.
 func (c *Channel) SendMessage(message *Message) {
+	c.mu.Lock()
 	c.lastEventID = message.id
+	c.mu.Unlock()
 
 	c.mu.RLock()
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/alexandrevicenzi/go-sse
+module github.com/iscander/go-sse
 
-go 1.11
+go 1.15

--- a/sse_test.go
+++ b/sse_test.go
@@ -90,8 +90,9 @@ func TestServer(t *testing.T) {
 }
 
 func TestMultipleTopics(t *testing.T) {
-	// usage pattern we have a client which subsribed to multiple channels
-	// in one connection
+	// The usage pattern: Imagine  we have a client which subsribed to multiple topics
+	// inside a connection. It track changes of specific items state by their ID
+	// for example.
 	sendersWg := sync.WaitGroup{}
 	workerWg := sync.WaitGroup{}
 	m := sync.Mutex{}

--- a/sse_test.go
+++ b/sse_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"sync"
 	"testing"
+	"time"
 )
 
 func TestNewServerNilOptions(t *testing.T) {
@@ -86,4 +87,68 @@ func TestServer(t *testing.T) {
 	if messageCount != channelCount*clientCount {
 		t.Errorf("Expected %d messages but got %d", channelCount*clientCount, messageCount)
 	}
+}
+
+func TestMultipleTopics(t *testing.T) {
+	// usage pattern we have a client which subsribed to multiple channels
+	// in one connection
+	sendersWg := sync.WaitGroup{}
+	workerWg := sync.WaitGroup{}
+	m := sync.Mutex{}
+	messageCount := 0
+	numMessages := 3
+	topics := []string{"Sunday", "Monday", "Tuesday", "Wednesday", "Thuesday", "Friday", "Saturday"}
+
+	srv := NewServer(&Options{
+		Logger: log.New(os.Stdout, "go-sse: ", log.Ldate|log.Ltime|log.Lshortfile),
+	})
+
+	defer srv.Shutdown()
+
+	name := "CH-0"
+	ch := srv.addChannel(name)
+	fmt.Printf("Channel %s registed\n", name)
+
+	// Create new client
+	c := newClient("", name)
+	// Add client to current channel
+	ch.addClient(c)
+
+	// receive messages
+	workerWg.Add(1)
+	go func() {
+		defer workerWg.Done()
+		// Wait for messages in the channel
+		for msg := range c.send {
+			m.Lock()
+			messageCount++
+			m.Unlock()
+			fmt.Printf("ID: %s - Topic: %s - Message: %s\n", msg.id, msg.event, msg.data)
+		}
+	}()
+
+	for _, day := range topics {
+		sendersWg.Add(1)
+		go func(topic string) {
+			defer sendersWg.Done()
+			for n := 0; n < numMessages; n++ {
+				srv.SendMessage(name, NewMessage(id(), "hello", topic))
+			}
+		}(day)
+	}
+	// Wait senders to complete
+	sendersWg.Wait()
+
+	srv.close()
+	// Wait recipient routine
+	workerWg.Wait()
+
+	if messageCount != len(topics)*numMessages {
+		t.Errorf("Expected %d messages but got %d", 3*numMessages, messageCount)
+	}
+
+}
+
+func id() string {
+	return fmt.Sprintf("%d", time.Now().UTC().Unix()*1000)
 }


### PR DESCRIPTION
Protect the option by wrapping into a mutex. The data race is gone.
It closes https://github.com/alexandrevicenzi/go-sse/issues/18

Provide fix and a unit test. The test was failing if run with race detection on.

go test -timeout 30s -v -race -run ^TestMultipleTopics$
....
==================
WARNING: DATA RACE
Write at 0x00c0000120d8 by goroutine 39:
  github.com/alexandrevicenzi/go-sse.(*Channel).SendMessage()
      /Users/iscander/projects/go-sse/channel.go:26 +0x8c
  github.com/alexandrevicenzi/go-sse.(*Server).SendMessage()
      /Users/iscander/projects/go-sse/sse.go:116 +0x21b
  github.com/alexandrevicenzi/go-sse.TestMultipleTopics.func2()
      /Users/iscander/projects/go-sse/sse_test.go:135 +0xce

Previous write at 0x00c0000120d8 by goroutine 38:
  github.com/alexandrevicenzi/go-sse.(*Channel).SendMessage()
      /Users/iscander/projects/go-sse/channel.go:26 +0x8c
  github.com/alexandrevicenzi/go-sse.(*Server).SendMessage()
      /Users/iscander/projects/go-sse/sse.go:116 +0x21b
  github.com/alexandrevicenzi/go-sse.TestMultipleTopics.func2()
      /Users/iscander/projects/go-sse/sse_test.go:135 +0xce

Goroutine 39 (running) created at:
  github.com/alexandrevicenzi/go-sse.TestMultipleTopics()
      /Users/iscander/projects/go-sse/sse_test.go:132 +0x735
  testing.tRunner()
      /usr/local/Cellar/go/1.16.3/libexec/src/testing/testing.go:1193 +0x202

Goroutine 38 (running) created at:
  github.com/alexandrevicenzi/go-sse.TestMultipleTopics()
      /Users/iscander/projects/go-sse/sse_test.go:132 +0x735
  testing.tRunner()
      /usr/local/Cellar/go/1.16.3/libexec/src/testing/testing.go:1193 +0x202
   ...