### PR TITLE
#Improve: Use more preferable way to specify logger - Interface

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/alexandrevicenzi/go-sse
 
-go 1.11
+go 1.18

--- a/options.go
+++ b/options.go
@@ -1,9 +1,15 @@
 package sse
 
 import (
-	"log"
 	"net/http"
 )
+
+// Logger Interface with all necessary functions to log.
+type LogPrinter interface {
+	Print(v ...any)
+	Println(v ...any)
+	Printf(format string, v ...any)
+}
 
 // Options holds server configurations.
 type Options struct {
@@ -15,7 +21,7 @@ type Options struct {
 	// Default channel name is the request path.
 	ChannelNameFunc func(*http.Request) string
 	// All usage logs end up in Logger
-	Logger *log.Logger
+	Logger LogPrinter
 }
 
 func (opt *Options) hasHeaders() bool {


### PR DESCRIPTION
1) By using Interface, you have posability pass any logger such as zap.Logger by using Adapter pattern.
I'm using it in my production code and it's work great, because I was need JSON logs, but it's bad idea to implement it by yourself.

2) Migrate from version 1.11 to 1.18 to get support 'any' predefined type.