### PR TITLE
Fix panic on sse-server shutdown

### DIFF
--- a/sse.go
+++ b/sse.go
@@ -15,7 +15,7 @@ type Server struct {
 	channels     map[string]*Channel
 	addClient    chan *Client
 	removeClient chan *Client
-	shutdown     chan bool
+	shutdown     chan struct{}
 	closeChannel chan string
 }
 
@@ -37,7 +37,7 @@ func NewServer(options *Options) *Server {
 		make(map[string]*Channel),
 		make(chan *Client),
 		make(chan *Client),
-		make(chan bool),
+		make(chan struct{}),
 		make(chan string),
 	}
 

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -1,0 +1,50 @@
+package tests
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/alexandrevicenzi/go-sse"
+)
+
+func TestServerShutdown(t *testing.T) {
+	sseServer := sse.NewServer(nil)
+	s := httptest.NewServer(sseServer)
+
+	ch := make(chan struct{})
+	ch2 := make(chan struct{})
+	defer close(ch)
+
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.URL, nil)
+		if err != nil {
+			t.Fail()
+		}
+		req.Header.Set("Cache-Control", "no-cache")
+		req.Header.Set("Accept", "text/event-stream")
+		req.Header.Set("Connection", "keep-alive")
+
+		_, err = http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fail()
+		}
+
+		close(ch2)
+		// Wait until the main test routine is done
+		<-ch
+	}()
+	// Wait until the HTTP request is sent
+	<-ch2
+
+	sseServer.Shutdown()
+	s.Close()
+
+	// Wait a bit after closing HTTP server
+	time.Sleep(250 * time.Millisecond)
+}


### PR DESCRIPTION
This is the fix for the "panic on sse-server shutdown when there is at least one active connection" issue.
It does the following:

1. after calling the Shutdown() function it doesn't allow new sse-connections to be established
2. it avoids sending to already closed removeClient channel